### PR TITLE
Use hardlineWithoutBreakParent to indent function bodies

### DIFF
--- a/src/handlers/primaryExpressions.ts
+++ b/src/handlers/primaryExpressions.ts
@@ -3,7 +3,7 @@ import printIfExist from "./util/printIfExists.ts";
 import space from "./util/space.ts";
 import type { Handler } from "./util/Handler.ts";
 
-const { join, line, group, indent, hardline, softline } = doc.builders;
+const { join, line, group, indent, hardline, softline, hardlineWithoutBreakParent } = doc.builders;
 
 const primaryExpressionHandlers: Record<string, Handler> = {
 	ParenthesizedExpr: (path, print, options) => {
@@ -66,7 +66,7 @@ const primaryExpressionHandlers: Record<string, Handler> = {
 		if (!exprPart) {
 			return "{}";
 		}
-		return group(["{", indent([hardline, path.map(print, "childrenByName", "Expr")]), hardline, "}"]);
+		return group(["{", indent([hardlineWithoutBreakParent, path.map(print, "childrenByName", "Expr")]), hardlineWithoutBreakParent, "}"]);
 	},
 };
 

--- a/test/functions.spec.ts
+++ b/test/functions.spec.ts
@@ -1,0 +1,53 @@
+import { describe, it } from 'node:test';
+import assert from 'node:assert';
+import * as prettier from 'prettier';
+import xqueryPlugin from '../src/main.ts';
+
+describe('functions', async (d) => {
+	it('correctly formats inline functions', async () => {
+		const code = `
+function () as xs:integer+ {
+  2, 3, 5, 7, 11, 13
+}
+`.trimStart();
+
+		const result = await prettier.format(code, {
+			parser: 'xquery',
+			plugins: [xqueryPlugin],
+		});
+
+		assert.strictEqual(result, code, 'The input was already formatted correctly');
+	});
+
+	it('correctly formats inline functions in let bindings', async () => {
+		const code = `
+let $x := function () as xs:integer+ {
+    2, 3, 5, 7, 11, 13
+  }
+return $x()
+`.trimStart();
+
+		const result = await prettier.format(code, {
+			parser: 'xquery',
+			plugins: [xqueryPlugin],
+		});
+
+		assert.strictEqual(result, code, 'The input was already formatted correctly');
+	});
+
+	it('correctly formats inline functions passed as arguments', async () => {
+		const code = `
+let $x := filter(function () as xs:integer+ {
+      2, 3, 5, 7, 11, 13
+    })
+return $x()
+`.trimStart();
+
+		const result = await prettier.format(code, {
+			parser: 'xquery',
+			plugins: [xqueryPlugin],
+		});
+
+		assert.strictEqual(result, code, 'The input was already formatted correctly');
+	});
+});


### PR DESCRIPTION
Makes them more readable if they are used in deeper indents