### PR TITLE
feat(newlines): keep empty lines intact while formatting

### DIFF
--- a/src/handlers/modulesAndPrologs.ts
+++ b/src/handlers/modulesAndPrologs.ts
@@ -1,4 +1,4 @@
-import { doc } from "prettier";
+import { doc, util } from "prettier";
 import type { Doc } from "prettier";
 import space from "./util/space.ts";
 import printIfExist from "./util/printIfExists.ts";
@@ -52,16 +52,20 @@ const modulesAndPrologsHandlers: Record<string, Handler> = {
 		return group([moduleDeclPart.length ? [moduleDeclPart, hardline, hardline] : [], prologPart]);
 	},
 	ModuleDecl: (path, print) => {
+		const moduleKeyword = path.map(print, 'childrenByName', "'module'");
+		const namespaceKeyword = path.map(print, 'childrenByName', "'namespace'");
 		const prefixPart = path.map(print, "childrenByName", "NCName");
 		const uriPart = path.map(print, "childrenByName", "URILiteral");
 		const separatorPart = path.map(print, "childrenByName", "Separator");
 
-		return group(["module", space, "namespace", space, prefixPart, space, "=", space, uriPart, separatorPart]);
+		return group([moduleKeyword, space, namespaceKeyword, space, prefixPart, space, "=", space, uriPart, separatorPart]);
 	},
 	NamespaceDecl: (path, print) => {
+		const declareKeyword = path.map(print, 'childrenByName', "'declare'");
+		const namespaceKeyword = path.map(print, 'childrenByName', "'namespace'");
 		const prefixPart = path.map(print, "childrenByName", "NCName");
 		const uriPart = path.map(print, "childrenByName", "URILiteral");
-		return group(["declare", space, "namespace", space, prefixPart, space, "=", space, uriPart]);
+		return group([declareKeyword, space, namespaceKeyword, space, prefixPart, space, "=", space, uriPart]);
 	},
 
 	SchemaImport: (path, print) => {
@@ -207,6 +211,7 @@ const modulesAndPrologsHandlers: Record<string, Handler> = {
 		if ((path.node.childrenByName.Prolog[0] as NonTerminalNode).children.length === 0) {
 			return group([prologPart, queryBodyPart]);
 		}
+
 		return group([prologPart.length ? [prologPart, hardline, hardline] : [], queryBodyPart]);
 	},
 	OptionDecl: (path, print) => {

--- a/src/handlers/primaryExpressions.ts
+++ b/src/handlers/primaryExpressions.ts
@@ -1,4 +1,4 @@
-import { doc } from "prettier";
+import { doc, util } from "prettier";
 import printIfExist from "./util/printIfExists.ts";
 import space from "./util/space.ts";
 import type { Handler } from "./util/Handler.ts";
@@ -14,7 +14,9 @@ const primaryExpressionHandlers: Record<string, Handler> = {
 		const lineType = shouldBreakAndIndent ? hardline : softline;
 
 		const children = printIfExist(path, print, "Expr");
-		const parenthesizedExpressionIsEmpty = !children && path.node.childrenByName["')'"][0].comments === undefined;
+		const positionAfterSpaces = util.skipWhitespace(options.originalText,path.node.begin +1, )
+		const parenthesizedExpressionIsEmpty = positionAfterSpaces && positionAfterSpaces === path.node.end! - 1
+
 		if (parenthesizedExpressionIsEmpty) {
 			return group([parenOpenKeyword, lineType, parenCloseKeyword]);
 		}

--- a/src/handlers/util/Handler.ts
+++ b/src/handlers/util/Handler.ts
@@ -1,5 +1,5 @@
-import type { AstPath, Doc, Options } from "prettier";
+import type { AstPath, Doc, Options, ParserOptions } from "prettier";
 import type { NonTerminalNode } from "../../tree.ts";
 import type { Print } from "./Print.ts";
 
-export type Handler = (path: AstPath<NonTerminalNode>, print: Print, options: Options) => Doc;
+export type Handler = (path: AstPath<NonTerminalNode>, print: Print, options: ParserOptions) => Doc;

--- a/src/handlers/util/isPreviousLineEmpty.ts
+++ b/src/handlers/util/isPreviousLineEmpty.ts
@@ -1,0 +1,9 @@
+import {util} from 'prettier';
+import { Node } from '../../tree.ts';
+
+export default function isPreviousLineEmpty(node: Node, {originalText}: {originalText: string}) {
+	if (node.comments && node.comments.length) {
+		return util.isPreviousLineEmpty(originalText, node.comments[0].begin)
+	}
+	return util.isPreviousLineEmpty(originalText, node.begin);
+}

--- a/src/handlers/util/joinChildrenWithSpaces.ts
+++ b/src/handlers/util/joinChildrenWithSpaces.ts
@@ -6,7 +6,8 @@ import { NonTerminalNode } from "../../tree.ts";
 
 const { join } = doc.builders;
 
-const joinChildrenWithSpaces = (path: AstPath<NonTerminalNode>, print: Print): Doc =>
-	join(space, path.map(print, "children"));
+const joinChildrenWithSpaces = (path: AstPath<NonTerminalNode>, print: Print): Doc =>{
+	return join(space, path.map(print, "children"));
+}
 
 export default joinChildrenWithSpaces;

--- a/src/handlers/util/printComment.ts
+++ b/src/handlers/util/printComment.ts
@@ -1,0 +1,9 @@
+import { doc, type Doc } from "prettier";
+import type { CommentNode } from "../../tree.ts";
+
+const { literallineWithoutBreakParent, join, group } = doc.builders;
+
+export default function printComment(node: CommentNode) {
+	const result: Doc[] = [join(literallineWithoutBreakParent, node.value.split("\n"))];
+	return group(result);
+}

--- a/src/tree.ts
+++ b/src/tree.ts
@@ -58,6 +58,12 @@ export class RootNode extends NonTerminalNode {
 }
 export class CommentNode extends Node {
 	public readonly value: string;
+
+	/**
+	 * Annotated by Prettier
+	 */
+	public placement?: "endOfLine" | "ownLine" | "remaining" = undefined;
+	public printed?: boolean = undefined;
 	constructor(begin: number, end: number, value: string) {
 		super("Comment", begin, end);
 		this.value = value;

--- a/test/assets/ignoreList.ts
+++ b/test/assets/ignoreList.ts
@@ -1,59 +1,14 @@
 /**
 * Automatically generated test report from running prettier over all 31821 test cases in the QT3 tests.
 *
-* The ignore list contains 19 known failing tests.
+* The ignore list contains 17 known failing tests.
 * Tests that fail because a comment failed to be printed: 15
 * Tests that fail because of a type error: 0
-* Tests that fail because the prettified result is not stable: 2
+* Tests that fail because the prettified result is not stable: 0
 *
 * Other failures: 2
 */
 export default {
-	"prod-DirAttributeList": {
-		"Constr-attr-enclexpr-12": [
-			"Error: Comment \"(:comment:)\" was not printed. Please report this error!"
-		]
-	},
-	"prod-DirElemContent": {
-		"K2-DirectConElemContent-26b": [
-			"Error: Comment \"(:comment:)\" was not printed. Please report this error!"
-		]
-	},
-	"prod-FunctionCall": {
-		"FunctionCall-046": [
-			"Error: Comment \"(: there's nothing here :)\" was not printed. Please report this error!"
-		],
-		"FunctionCall-047": [
-			"Error: Comment \"(: there's nothing here :)\" was not printed. Please report this error!"
-		],
-		"FunctionCall-048": [
-			"Error: Comment \"(: there's nothing here :)\" was not printed. Please report this error!"
-		],
-		"FunctionCall-055": [
-			"AssertionError [ERR_ASSERTION]: The prettification should be stable after a first one",
-			"+ actual - expected",
-			"... Skipped lines",
-			"",
-			"  'declare function local:product ($s as xs:double+) as xs:double {\\n' +",
-			"    '  if (not($s[2])) then\\n' +",
-			"    '    $s[1]\\n' +",
-			"    '  else\\n' +",
-			"    '    $s[1] * local:product($s[position() > 1])\\n' +",
-			"...",
-			"    'local:product((1, \"2\", 3))\\n' +",
-			"+   \" (: '2' is not xs:double, error should be raised :)\"",
-			"-   \"(: '2' is not xs:double, error should be raised :) \"",
-			""
-		]
-	},
-	"prod-FunctionDecl": {
-		"function-declaration-029": [
-			"Error: Comment \"(:there is nothing here:)\" was not printed. Please report this error!"
-		],
-		"function-declaration-030": [
-			"Error: Comment \"(:there is nothing here:)\" was not printed. Please report this error!"
-		]
-	},
 	"prod-GroupByClause": {
 		"group-009": [
 			"AssertionError [ERR_ASSERTION]: Got unwanted rejection: The second prettification should also work3.",
@@ -147,24 +102,33 @@ export default {
 			"Error: Comment \"(::)\" was not printed. Please report this error!"
 		]
 	},
-	"fn-unparsed-text": {
-		"fn-unparsed-text-054a": [
-			"AssertionError [ERR_ASSERTION]: The prettification should be stable after a first one",
-			"+ actual - expected",
-			"",
-			"  'for $t1 in unparsed-text(\"https://timeanddate.com\")\\n' +",
-			"    'return every\\n' +",
-			"    '    $i in\\n' +",
-			"    '    1 to 50 satisfies\\n' +",
-			"    '    (\\n' +",
-			"+   '      parse-xml(\"<a><b><c>\" || $i || \"</c></b></a>\")//c (:waste some time:) and\\n' +",
-			"-   '      parse-xml(\"<a><b><c>\" || $i || \"</c></b></a>\")//c(:waste some time:)  and\\n' +",
-			"    '        unparsed-text(\\n' +",
-			"    '          translate(concat(\"https://timeanddate.com\", $i), \"0123456789\", \"\")\\n' +",
-			"    '        ) eq\\n' +",
-			"    '          $t1\\n' +",
-			"    '    )\\n'",
-			""
+	"prod-DirAttributeList": {
+		"Constr-attr-enclexpr-12": [
+			"Error: Comment \"(:comment:)\" was not printed. Please report this error!"
+		]
+	},
+	"prod-DirElemContent": {
+		"K2-DirectConElemContent-26b": [
+			"Error: Comment \"(:comment:)\" was not printed. Please report this error!"
+		]
+	},
+	"prod-FunctionCall": {
+		"FunctionCall-046": [
+			"Error: Comment \"(: there's nothing here :)\" was not printed. Please report this error!"
+		],
+		"FunctionCall-047": [
+			"Error: Comment \"(: there's nothing here :)\" was not printed. Please report this error!"
+		],
+		"FunctionCall-048": [
+			"Error: Comment \"(: there's nothing here :)\" was not printed. Please report this error!"
+		]
+	},
+	"prod-FunctionDecl": {
+		"function-declaration-029": [
+			"Error: Comment \"(:there is nothing here:)\" was not printed. Please report this error!"
+		],
+		"function-declaration-030": [
+			"Error: Comment \"(:there is nothing here:)\" was not printed. Please report this error!"
 		]
 	}
 } as Record<string,Record<string,string>>;

--- a/test/assets/qt3-snapshots/app-CatalogCheck/Catalog009.xquery
+++ b/test/assets/qt3-snapshots/app-CatalogCheck/Catalog009.xquery
@@ -8,6 +8,7 @@ let $name := $dependencyTS/@type
 let $value := $dependencyTS/@value
 group by $name, $value
 order by $name , $value
+
 return <dependency type='{
     $name
   }' value='{

--- a/test/assets/qt3-snapshots/app-CatalogCheck/Catalog014.xquery
+++ b/test/assets/qt3-snapshots/app-CatalogCheck/Catalog014.xquery
@@ -15,8 +15,8 @@ where not(
     "fo-test-"
   (: special exemption for generated tests :) )
 )
-where xs:date($test/created/@on) le
-  xs:date("2018-01-01") (: no point keeping this requirement any longer :)
+(: no point keeping this requirement any longer :)
+where xs:date($test/created/@on) le xs:date("2018-01-01")
 return <out test="{
     $test/@name
   }"/>

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-1.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-1.xquery
@@ -7,9 +7,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-2.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-2.xquery
@@ -7,9 +7,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-3.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-3.xquery
@@ -7,9 +7,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-all.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-days-in-month-all.xquery
@@ -7,9 +7,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-1.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-1.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-2.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-2.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-3.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-3.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-all.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-month-all.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-1.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-1.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-2.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-2.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-3.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-3.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-all.xquery
+++ b/test/assets/qt3-snapshots/app-FunctxFunctx/functx-functx-last-day-of-year-all.xquery
@@ -24,9 +24,9 @@ declare function functx:days-in-month (
   if (month-from-date(xs:date($date)) = 2 and functx:is-leap-year($date)) then
     29
   else
-    (31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31)[month-from-date(
-      xs:date($date)
-    )]
+    (
+      31, 28, 31, 30, 31, 30, 31, 31, 30, 31, 30, 31
+    )[month-from-date(xs:date($date))]
 };
 
 (:~ : Whether a date falls in a leap year : : @author Priscilla Walmsley, Datypic : @version 1.0 : @see http://www.xqueryfunctions.com/xq/functx_is-leap-year.html : @param $date the date or year :)

--- a/test/assets/qt3-snapshots/app-UseCaseR31/UseCaseR31-034-err.xquery
+++ b/test/assets/qt3-snapshots/app-UseCaseR31/UseCaseR31-034-err.xquery
@@ -1,6 +1,7 @@
 let $mf := function ($k as node(), $v) {
     map {$k("book"): $v}
   }
+
 return $mf(
     json-doc("http://www.w3.org/qt3/app/UseCaseR31/bookinfo-json"),
     "first"

--- a/test/assets/qt3-snapshots/app-UseCaseSTRING/string-queries-results-q2.xquery
+++ b/test/assets/qt3-snapshots/app-UseCaseSTRING/string-queries-results-q2.xquery
@@ -8,6 +8,7 @@ declare function local:partners ($company as xs:string) as element()* {
 };
 
 let $foobar_partners := local:partners("Foobar Corporation")
+
 for $item in $input-context1//news_item
 where some
   $t in

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-date-to-timezone-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-date-to-timezone-003.xquery
@@ -1,2 +1,3 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-date-to-timezone(xs:date("2002-03-07"), $tz-10)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-date-to-timezone-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-date-to-timezone-004.xquery
@@ -1,2 +1,3 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-date-to-timezone(xs:date("2002-03-07-07:00"), $tz-10)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-dateTime-to-timezone-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-dateTime-to-timezone-002.xquery
@@ -1,2 +1,3 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-dateTime-to-timezone(xs:dateTime("2002-03-07T10:00:00-07:00"))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-dateTime-to-timezone-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-dateTime-to-timezone-003.xquery
@@ -1,4 +1,5 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-dateTime-to-timezone(
     xs:dateTime("2002-03-07T10:00:00"),
     $tz-10

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-dateTime-to-timezone-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-dateTime-to-timezone-004.xquery
@@ -1,4 +1,5 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-dateTime-to-timezone(
     xs:dateTime("2002-03-07T10:00:00-07:00"),
     $tz-10

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-time-to-timezone-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-time-to-timezone-003.xquery
@@ -1,2 +1,3 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-time-to-timezone(xs:time("10:00:00"), $tz-10)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-time-to-timezone-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-adjust-time-to-timezone-004.xquery
@@ -1,2 +1,3 @@
 let $tz-10 := xs:dayTimeDuration("-PT10H")
+
 return fn:adjust-time-to-timezone(xs:time("10:00:00-07:00"), $tz-10)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-avg-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-avg-001.xquery
@@ -1,2 +1,3 @@
 let $seq3 := (3, 4, 5)
+
 return fn:avg($seq3)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-avg-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-avg-002.xquery
@@ -1,3 +1,5 @@
 let $d1 := xs:yearMonthDuration("P20Y")
+
 return let $d2 := xs:yearMonthDuration("P10M")
+
   return fn:avg(($d1, $d2))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-avg-005.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-avg-005.xquery
@@ -1,2 +1,3 @@
 let $seq3 := (3, 4, 5)
+
 return fn:avg(($seq3, xs:float("NaN")))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-boolean-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-boolean-001.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "")
+
 return fn:boolean($abc[1])

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-boolean-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-boolean-002.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "")
+
 return fn:boolean($abc[0])

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-boolean-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-boolean-003.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "")
+
 return fn:boolean($abc[3])

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-collation-key-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-collation-key-001.xquery
@@ -1,4 +1,5 @@
 let $C := "http://www.w3.org/2013/collation/UCA?strength=primary"
+
 return map:merge(
     (map {collation-key("A", $C): 1}, map {collation-key("a", $C): 2}),
     map {"duplicates": "use-last"}

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-collation-key-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-collation-key-002.xquery
@@ -1,3 +1,4 @@
 let $C := "http://www.w3.org/2013/collation/UCA?strength=primary"
+
 return let $M := map {collation-key("A", $C): 1, collation-key("B", $C): 2}
   return $M(collation-key("a", $C))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-001.xquery
@@ -8,6 +8,9 @@ let $po :=
          <quantity>805</quantity> </line-item>
          </PurchaseOrder>
 return let $item1 := $po/line-item[1]
+
   return let $item2 := $po/line-item[2]
+
     return let $seq1 := ($item1, $item2)
+
       return fn:count($seq1)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-002.xquery
@@ -1,2 +1,3 @@
 let $seq3 := ()
+
 return fn:count($seq3)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-003.xquery
@@ -1,2 +1,3 @@
 let $seq2 := (98.5, 98.3, 98.9)
+
 return fn:count($seq2)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-count-004.xquery
@@ -1,2 +1,3 @@
 let $seq2 := (98.5, 98.3, 98.9)
+
 return fn:count($seq2[. > 100])

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-data-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-data-004.xquery
@@ -1,3 +1,4 @@
 let $para :=
   <para>In a hole in the ground there lived a <term author="Tolkien">hobbit</term>.</para>
+
 return data($para)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-data-005.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-data-005.xquery
@@ -1,3 +1,4 @@
 let $para :=
   <para>In a hole in the ground there lived a <term author="Tolkien">hobbit</term>.</para>
+
 return data($para/term/@author)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-element-with-id-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-element-with-id-001.xquery
@@ -7,4 +7,5 @@ let $emp := validate lax { document {
                <last>Brown</last>
             </employee>
     } }
+
 return $emp/fn:element-with-id("ID21256")/name()

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-element-with-id-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-element-with-id-002.xquery
@@ -7,4 +7,5 @@ let $emp := validate lax { document {
                <last>Brown</last>
             </employee>
     } }
+
 return $emp/fn:element-with-id("E21256")/name()

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-id-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-id-001.xquery
@@ -7,4 +7,5 @@ let $emp := validate lax { document {
                <last>Brown</last>
             </employee>
     } }
+
 return $emp/id("ID21256")/name()

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-id-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-id-002.xquery
@@ -7,4 +7,5 @@ let $emp := validate lax { document {
                <last>Brown</last>
             </employee>
     } }
+
 return $emp/id("E21256")/name()

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-idref-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-idref-001.xquery
@@ -15,6 +15,7 @@ let $emp := validate lax { document {
             </employee>
           </employees>
     } }
+
 return $emp/(
     element-with-id("ID21256")/@xml:id => fn:idref()
   )/ancestor::employee/last

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-idref-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-idref-002.xquery
@@ -15,6 +15,7 @@ let $emp := validate lax { document {
             </employee>
           </employees>
     } }
+
 return $emp/(
     element-with-id("E30561")/empnr => fn:idref()
   )/ancestor::employee/last

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-001.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:insert-before($abc, 0, "z")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-002.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:insert-before($abc, 1, "z")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-003.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:insert-before($abc, 2, "z")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-004.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:insert-before($abc, 3, "z")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-005.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-insert-before-005.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:insert-before($abc, 4, "z")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-number-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-number-001.xquery
@@ -8,4 +8,5 @@ let $po :=
          <quantity>805</quantity> </line-item>
          </PurchaseOrder>
 return let $item1 := $po/line-item[1]
+
   return fn:number($item1/quantity)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-number-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-number-002.xquery
@@ -8,4 +8,5 @@ let $po :=
          <quantity>805</quantity> </line-item>
          </PurchaseOrder>
 return let $item2 := $po/line-item[2]
+
   return fn:number($item2/description)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-001.xquery
@@ -5,4 +5,5 @@ Tochter aus Elysium,<br/>
 Wir betreten feuertrunken,<br/>
 Himmlische, dein Heiligtum.</p>
   }
+
 return fn:path($e)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-002.xquery
@@ -5,4 +5,5 @@ Tochter aus Elysium,<br/>
 Wir betreten feuertrunken,<br/>
 Himmlische, dein Heiligtum.</p>
   }
+
 return fn:path($e/*:p)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-003.xquery
@@ -5,4 +5,5 @@ Tochter aus Elysium,<br/>
 Wir betreten feuertrunken,<br/>
 Himmlische, dein Heiligtum.</p>
   }
+
 return fn:path($e/*:p/@xml:lang)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-004.xquery
@@ -5,4 +5,5 @@ Tochter aus Elysium,<br/>
 Wir betreten feuertrunken,<br/>
 Himmlische, dein Heiligtum.</p>
   }
+
 return fn:path($e/*:p/@author)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-005.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-005.xquery
@@ -5,4 +5,5 @@ Tochter aus Elysium,<br/>
 Wir betreten feuertrunken,<br/>
 Himmlische, dein Heiligtum.</p>
   }
+
 return fn:path($e/*:p/*:br[2])

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-006.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-006.xquery
@@ -5,4 +5,5 @@ Tochter aus Elysium,<br/>
 Wir betreten feuertrunken,<br/>
 Himmlische, dein Heiligtum.</p>
   }
+
 return fn:path($e//text()[starts-with(normalize-space(), "Tochter")])

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-007.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-007.xquery
@@ -4,4 +4,5 @@ let $emp :=
                <first>John</first>
                <last>Brown</last>
             </employee>
+
 return fn:path($emp)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-008.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-008.xquery
@@ -4,4 +4,5 @@ let $emp :=
                <first>John</first>
                <last>Brown</last>
             </employee>
+
 return fn:path($emp/@xml:id)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-009.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-path-009.xquery
@@ -4,4 +4,5 @@ let $emp :=
                <first>John</first>
                <last>Brown</last>
             </employee>
+
 return fn:path($emp/empnr)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-001.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:remove($abc, 0)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-002.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:remove($abc, 1)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-003.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:remove($abc, 6)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-remove-004.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:remove((), 3)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-reverse-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-reverse-001.xquery
@@ -1,2 +1,3 @@
 let $abc := ("a", "b", "c")
+
 return fn:reverse($abc)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-serialize-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-serialize-001.xquery
@@ -3,5 +3,7 @@ let $params :=
         xmlns:output="http://www.w3.org/2010/xslt-xquery-serialization">
   <output:omit-xml-declaration value="yes"/>
 </output:serialization-parameters>
+
 return let $data := <a b="3"/>
+
   return fn:serialize($data, $params)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-serialize-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-serialize-002.xquery
@@ -1,4 +1,5 @@
 let $data := <a b="3"/>
+
 return fn:serialize(
     $data,
     map {"method": "xml", "omit-xml-declaration": true()}

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-string-007.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-string-007.xquery
@@ -1,3 +1,4 @@
 let $para :=
   <para>In a hole in the ground there lived a <term author="Tolkien">hobbit</term>.</para>
+
 return string($para)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-subsequence-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-subsequence-001.xquery
@@ -1,2 +1,3 @@
 let $seq := ("item1", "item2", "item3", "item4", "item5")
+
 return fn:subsequence($seq, 4)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-subsequence-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-subsequence-002.xquery
@@ -1,2 +1,3 @@
 let $seq := ("item1", "item2", "item3", "item4", "item5")
+
 return fn:subsequence($seq, 3, 2)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-001.xquery
@@ -1,3 +1,5 @@
 let $d1 := xs:yearMonthDuration("P20Y")
+
 return let $d2 := xs:yearMonthDuration("P10M")
+
   return fn:sum(($d1, $d2))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-002.xquery
@@ -1,6 +1,9 @@
 let $d1 := xs:yearMonthDuration("P20Y")
+
 return let $d2 := xs:yearMonthDuration("P10M")
+
   return let $seq1 := ($d1, $d2)
+
     return fn:sum(
         $seq1[. lt xs:yearMonthDuration("P3M")],
         xs:yearMonthDuration("P0M")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-003.xquery
@@ -1,2 +1,3 @@
 let $seq3 := (3, 4, 5)
+
 return fn:sum($seq3)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-007.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-fn-sum-007.xquery
@@ -1,3 +1,5 @@
 let $d1 := xs:yearMonthDuration("P20Y")
+
 return let $d2 := xs:yearMonthDuration("P10M")
+
   return fn:sum(($d1, $d2), "ein Augenblick")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-contains-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-contains-001.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:contains($week, 2)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-contains-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-contains-002.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:contains($week, 9)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-001.xquery
@@ -3,4 +3,5 @@ let $responses :=
     0: "nein",
     1: ("ja", "doch")
   }]
+
 return map:find($responses, 0)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-002.xquery
@@ -3,4 +3,5 @@ let $responses :=
     0: "nein",
     1: ("ja", "doch")
   }]
+
 return map:find($responses, 1)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-003.xquery
@@ -3,4 +3,5 @@ let $responses :=
     0: "nein",
     1: ("ja", "doch")
   }]
+
 return map:find($responses, 2)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-find-004.xquery
@@ -4,4 +4,5 @@ let $inventory :=
     "id": "QZ123",
     "parts": [map {"name": "engine", "id": "YW678", "parts": []}]
   }
+
 return map:find($inventory, "parts")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-get-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-get-001.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:get($week, 4)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-get-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-get-002.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:get($week, 9)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-003.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:merge(($week, map {7: "Unbekannt"}))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-004.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:merge(($week, map {6: "Sonnabend"}), map {"duplicates": "use-last"})

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-005.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-005.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:merge(($week, map {6: "Sonnabend"}), map {"duplicates": "use-first"})

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-006.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-merge-006.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:merge(($week, map {6: "Sonnabend"}), map {"duplicates": "combine"})

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-put-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-put-001.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:put($week, 6, "Sonnabend")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-put-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-put-002.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:put($week, -1, "Unbekannt")

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-001.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-001.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:remove($week, 4)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-002.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-002.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:remove($week, 23)

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-003.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-003.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:remove($week, (0, 6 to 7))

--- a/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-004.xquery
+++ b/test/assets/qt3-snapshots/app-spec-examples/fo-test-map-remove-004.xquery
@@ -8,4 +8,5 @@ let $week :=
     5: "Freitag",
     6: "Samstag"
   }
+
 return map:remove($week, ())

--- a/test/assets/qt3-snapshots/array-sort/array-sort-026.xquery
+++ b/test/assets/qt3-snapshots/array-sort/array-sort-026.xquery
@@ -26,6 +26,7 @@ declare function local:permute (
 };
 
 let $s := ("A", "B", "C")
+
 return array:sort(local:permute($s), (), function ($s) {
       $s!.
     }) => array:for-each(string-join#1)

--- a/test/assets/qt3-snapshots/fn-fold-left/fold-left-008.xquery
+++ b/test/assets/qt3-snapshots/fn-fold-left/fold-left-008.xquery
@@ -20,4 +20,5 @@ let $hours := function ($emp as element(employee)) as xs:integer {
       }
     )
   }
+
 return $highest($hours, /works/employee)

--- a/test/assets/qt3-snapshots/fn-random-number-generator/fn-random-number-generator-22.xquery
+++ b/test/assets/qt3-snapshots/fn-random-number-generator/fn-random-number-generator-22.xquery
@@ -13,6 +13,7 @@ declare function local:random-sequence (
 };
 
 let $r := local:random-sequence(200)
+
 return if (not(count(distinct-values($r)) >= 0.5 * count($r))) then
     fn:false()
   else if (not(not(deep-equal($r, fn:sort($r))))) then

--- a/test/assets/qt3-snapshots/fn-unparsed-text/fn-unparsed-text-054.xquery
+++ b/test/assets/qt3-snapshots/fn-unparsed-text/fn-unparsed-text-054.xquery
@@ -3,7 +3,7 @@ return every
     $i in
     1 to 50 satisfies
     (
-      parse-xml("<a><b><c>" || $i || "</c></b></a>")//c(:waste some time:)  and
+      parse-xml("<a><b><c>" || $i || "</c></b></a>")//c (:waste some time:) and
         unparsed-text(
           translate(concat("http://date.jsontest.com", $i), "0123456789", "")
         ) eq

--- a/test/assets/qt3-snapshots/fn-unparsed-text/fn-unparsed-text-054a.xquery
+++ b/test/assets/qt3-snapshots/fn-unparsed-text/fn-unparsed-text-054a.xquery
@@ -1,0 +1,11 @@
+for $t1 in unparsed-text("https://timeanddate.com")
+return every
+    $i in
+    1 to 50 satisfies
+    (
+      parse-xml("<a><b><c>" || $i || "</c></b></a>")//c (:waste some time:) and
+        unparsed-text(
+          translate(concat("https://timeanddate.com", $i), "0123456789", "")
+        ) eq
+          $t1
+    )

--- a/test/assets/qt3-snapshots/op-same-key/same-key-023.xquery
+++ b/test/assets/qt3-snapshots/op-same-key/same-key-023.xquery
@@ -2,7 +2,9 @@ let $keys :=
   let $range := 48 to 122
   for $c1 in $range, $c2 in $range, $c3 in $range
   return codepoints-to-string(($c1, $c2, $c3))
+
 let $map := map:merge(($keys, $keys)!map:entry(., .))
+
 return map:size($map) eq count($keys) and
     (
       every

--- a/test/assets/qt3-snapshots/op-same-key/same-key-024.xquery
+++ b/test/assets/qt3-snapshots/op-same-key/same-key-024.xquery
@@ -14,8 +14,10 @@ let $keys :=
         default return
           error()
     )
+
 let $map :=
   map:merge(($keys, $keys)!map:entry(., .), map {"duplicates": "use-last"})
+
 return map:size($map) eq count($keys) and
     (
       every

--- a/test/assets/qt3-snapshots/prod-AxisStep/Axes089.xquery
+++ b/test/assets/qt3-snapshots/prod-AxisStep/Axes089.xquery
@@ -65,17 +65,17 @@ declare function tour:main () as element() {
     let $empty-board as xs:integer* :=
       for $i in (1 to 64)
       return 0
-    (: Place the knight on the board at the chosen starting position :)
 
+    (: Place the knight on the board at the chosen starting position :)
     let $initial-board as xs:integer* :=
       tour:place-knight(1, $empty-board, $start-row * 8 + $start-column)
-    (: Evaluate the knight's tour :)
 
+    (: Evaluate the knight's tour :)
     let $final-board as xs:integer* :=
       tour:make-moves(2, $initial-board, $start-row * 8 + $start-column)
-    (: produce the HTML output :)
 
-      return tour:print-board($final-board)
+    (: produce the HTML output :)
+    return tour:print-board($final-board)
 };
 
 declare function tour:place-knight (
@@ -107,9 +107,9 @@ declare function tour:make-moves (
 
   let $possible-move-list as xs:integer* :=
     tour:list-possible-moves($board, $square)
-  (: try these moves in turn until one is found that works :)
 
-    return tour:try-possible-moves($move, $board, $square, $possible-move-list)
+  (: try these moves in turn until one is found that works :)
+  return tour:try-possible-moves($move, $board, $square, $possible-move-list)
 };
 
 declare function tour:try-possible-moves (
@@ -150,25 +150,25 @@ declare function tour:make-best-move (
 
   let $best-move as xs:integer :=
     tour:find-best-move($board, $possible-moves, 9, 999)
+
   (: find the list of possible moves excluding the best one :)
-
   let $other-possible-moves as xs:integer* := $possible-moves[. != $best-move]
+
   (: update the board to make the move chosen as the best one :)
-
   let $next-board as xs:integer* := tour:place-knight($move, $board, $best-move)
-  (: now make further moves using a recursive call, until the board is complete :)
 
+  (: now make further moves using a recursive call, until the board is complete :)
   let $final-board as xs:integer* :=
     if ($move < $endd) (:count($next-board[.=0])!=0:) then
       tour:make-moves($move + 1, $next-board, $best-move)
     else
       $next-board
+
   (:   if the final board has the special value '()', we got stuck, and have to choose
          the next best of the possible moves. This is done by a recursive call. I thought
          that the knight never did get stuck, but it does: if the starting square is f1,
          the wrong choice is made at move 58, and needs to be reversed. :)
-
-    return if (empty($final-board)) then
+  return if (empty($final-board)) then
       tour:try-possible-moves($move, $board, $square, $other-possible-moves)
     else
       $final-board
@@ -186,29 +186,31 @@ declare function tour:find-best-move (
   (:  split the list of possible moves into the first move and the rest of the moves :)
 
   let $trial-move as xs:integer := $possible-moves[1]
+
   let $other-possible-moves as xs:integer* := $possible-moves[position() > 1]
+
   (: try making the first move :)
-
   let $trial-board as xs:integer* := tour:place-knight(99, $board, $trial-move)
-  (: see how many moves would be possible the next time :)
 
+  (: see how many moves would be possible the next time :)
   let $trial-move-exit-list as xs:integer* :=
     tour:list-possible-moves($trial-board, $trial-move)
+
   let $number-of-exits as xs:integer := count($trial-move-exit-list)
+
   (:  determine whether this trial move has fewer exits than those considered up till now :)
-
   let $minimum-exits as xs:integer := min(($number-of-exits, $fewest-exits))
-  (:  determine which is the best move (the one with fewest exits) so far :)
 
+  (:  determine which is the best move (the one with fewest exits) so far :)
   let $new-best-so-far as xs:integer :=
     if ($number-of-exits < $fewest-exits) then
       $trial-move
     else
       $best-so-far
+
   (:  if there are other possible moves, consider them too, using a recursive call.
         Otherwise return the best move found. :)
-
-    return if (count($other-possible-moves) != 0) then
+  return if (count($other-possible-moves) != 0) then
       tour:find-best-move(
         $board,
         $other-possible-moves,
@@ -228,6 +230,7 @@ declare function tour:list-possible-moves (
 
   let $row as xs:integer := $square idiv 8
   let $column as xs:integer := $square mod 8
+
   return (
       if ($row > 1 and $column > 0 and $board[($square - 17) + 1] = 0) then
         $square - 17

--- a/test/assets/qt3-snapshots/prod-DirAttributeList/Constr-attr-enclexpr-12.xquery
+++ b/test/assets/qt3-snapshots/prod-DirAttributeList/Constr-attr-enclexpr-12.xquery
@@ -1,0 +1,1 @@
+<elem attr="z (:comment:){}z"/>

--- a/test/assets/qt3-snapshots/prod-DirElemContent/K2-DirectConElemContent-26b.xquery
+++ b/test/assets/qt3-snapshots/prod-DirElemContent/K2-DirectConElemContent-26b.xquery
@@ -1,0 +1,1 @@
+<elem>content (:comment:){}content</elem>

--- a/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-046.xquery
+++ b/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-046.xquery
@@ -1,0 +1,2 @@
+let $f := function ($x) (: there's nothing here :) {}
+return $f(2)

--- a/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-047.xquery
+++ b/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-047.xquery
@@ -1,0 +1,3 @@
+let $f :=
+  function ($x as xs:integer) as xs:integer? (: there's nothing here :) {}
+return $f(2)

--- a/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-048.xquery
+++ b/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-048.xquery
@@ -1,0 +1,3 @@
+let $f :=
+  function ($x as xs:integer) as xs:integer (: there's nothing here :) {}
+return $f(2)

--- a/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-055.xquery
+++ b/test/assets/qt3-snapshots/prod-FunctionCall/FunctionCall-055.xquery
@@ -1,0 +1,8 @@
+declare function local:product ($s as xs:double+) as xs:double {
+  if (not($s[2])) then
+    $s[1]
+  else
+    $s[1] * local:product($s[position() > 1])
+};
+
+local:product((1, "2", 3)) (: '2' is not xs:double, error should be raised :)

--- a/test/assets/qt3-snapshots/prod-FunctionDecl/function-declaration-029.xquery
+++ b/test/assets/qt3-snapshots/prod-FunctionDecl/function-declaration-029.xquery
@@ -1,0 +1,3 @@
+declare function local:function ($x) (:there is nothing here:) {};
+
+local:function(3)

--- a/test/assets/qt3-snapshots/prod-FunctionDecl/function-declaration-030.xquery
+++ b/test/assets/qt3-snapshots/prod-FunctionDecl/function-declaration-030.xquery
@@ -1,0 +1,5 @@
+declare function local:function (
+  $x as xs:integer
+) as xs:integer (:there is nothing here:) {};
+
+local:function(3)

--- a/test/assets/qt3-snapshots/prod-WindowClause/SlidingWindowExpr561.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/SlidingWindowExpr561.xquery
@@ -37,6 +37,7 @@ declare
     )
   return for $trip in $trips
     let $tripDate := $trip/@date, $tripName := $trip/@name
+
     group by $tripDate, $tripName
     let $totalDuration := sum($trip/@duration/xs:dayTimeDuration(.))
     order by $tripDate descending, $tripName

--- a/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr531.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr531.xquery
@@ -1,6 +1,5 @@
 for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
   start $first when $first mod 3 = 0
-
 return <window>{
     $w
   }</window>

--- a/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr531a.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr531a.xquery
@@ -1,7 +1,6 @@
 <o>{
   for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
     start $first when $first mod 3 = 0
-
   return <window>{
       $w
     }</window>

--- a/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr532.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr532.xquery
@@ -1,7 +1,6 @@
 for $w in (1 to 2)
 for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
   start $first when $first mod 3 = 0
-
 return <window>{
     $w
   }</window>

--- a/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr533.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr533.xquery
@@ -1,7 +1,6 @@
 for $w in (1 to 2)
 for tumbling window $w in (2, 4, 6, 8, 10, 12, 14)
   start $first when $first mod $y = 0
-
 return <window>{
     $y
   }</window>

--- a/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr560.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/TumblingWindowExpr560.xquery
@@ -8,7 +8,6 @@ declare option output:indent "yes";
 let $results :=
   for tumbling window $chunk in /*/*
     start at $sp when $sp mod $chunk-size = 1
-
   return document {
       element {node-name(head($chunk)/..)} {
         $chunk

--- a/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase04.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase04.xquery
@@ -1,4 +1,5 @@
 let $MAX_DIFF := 2
+
 for sliding window $w in ./stream/event
   start $s_curr
   at $s_pos

--- a/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase04S.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase04S.xquery
@@ -1,4 +1,5 @@
 let $MAX_DIFF := 2
+
 for sliding window $w in ./stream/event
   start $s_curr
   at $s_pos

--- a/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase05.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase05.xquery
@@ -1,4 +1,5 @@
 let $SMOOTH_CONST := 0.2
+
 for sliding window $w in ./stream/event
   start at $s_pos when true()
   only end at $e_pos when $e_pos - $s_pos eq 2

--- a/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase05S.xquery
+++ b/test/assets/qt3-snapshots/prod-WindowClause/WindowingUseCase05S.xquery
@@ -1,4 +1,5 @@
 let $SMOOTH_CONST := 0.2
+
 for sliding window $w in ./stream/event
   start at $s_pos when true()
   only end at $e_pos when $e_pos - $s_pos eq 2

--- a/test/comments.spec.ts
+++ b/test/comments.spec.ts
@@ -36,4 +36,39 @@ declare variable $x := "A"; (: A :)
 
 		assert.strictEqual(result, code, "The input was already formatted correctly");
 	});
+
+	it("Keeps comments on their own lines", async () => {
+		const code = `
+(
+  (: A leading comment:) A,
+  (: On its own line :)
+  B,
+  C (: Trailing now :)
+)
+`.trimStart();
+
+		const result = await prettier.format(code, {
+			parser: "xquery",
+			plugins: [xqueryPlugin],
+		});
+
+		assert.strictEqual(result, code, "The input was already formatted correctly");
+	});
+
+	it("handles comments separated with newlines", async () => {
+		const code = `
+(:a:)
+
+(:b:)
+
+a
+`.trimStart();
+
+		const result = await prettier.format(code, {
+			parser: "xquery",
+			plugins: [xqueryPlugin],
+		});
+
+		assert.strictEqual(result, code, "The input was already formatted correctly");
+	});
 });

--- a/test/flworExpressions.spec.ts
+++ b/test/flworExpressions.spec.ts
@@ -1,0 +1,102 @@
+import { describe, it } from "node:test";
+import assert from "node:assert";
+import * as prettier from "prettier";
+import xqueryPlugin from "../src/main.ts";
+
+const cases = [
+	{
+		name: "formats a simple case",
+		input: `
+let $x := 1
+return $x
+`.trimStart(),
+		output: `
+let $x := 1
+return $x
+`.trimStart(),
+	},
+	{
+		name: "retains newlines",
+		input: `
+let $x := 1
+
+for $x in ($x to 10)
+
+return $x
+`,
+		output: `
+let $x := 1
+
+for $x in ($x to 10)
+
+return $x
+`.trimStart(),
+	},
+	{
+		name: "normalizes newlines to a single one",
+		input: `
+let $x := 1
+
+
+
+
+for $x in ($x to 10)
+
+
+
+
+
+return $x
+`,
+		output: `
+let $x := 1
+
+for $x in ($x to 10)
+
+return $x
+`.trimStart(),
+	},
+	{
+		name: "retains comments",
+		input: `
+(: Declare $x :)
+let $x := 1
+
+
+
+
+(: For 10 times, do :)
+for $x in ($x to 10)
+
+
+
+
+(: Add one to the current value of $x :)
+return $x + 1
+`,
+		output: `
+(: Declare $x :)
+let $x := 1
+
+(: For 10 times, do :)
+for $x in ($x to 10)
+
+(: Add one to the current value of $x :)
+return $x + 1
+`.trimStart(),
+	},
+];
+
+describe("flwor expressions", async (d) => {
+	for (const test of cases) {
+		it(test.name, async () => {
+			const code = test.input;
+			const result = await prettier.format(code, {
+				parser: "xquery",
+				plugins: [xqueryPlugin],
+			});
+
+			assert.strictEqual(result, test.output);
+		});
+	}
+});

--- a/test/ifExpr.spec.ts
+++ b/test/ifExpr.spec.ts
@@ -3,41 +3,46 @@ import assert from "node:assert";
 import * as prettier from "prettier";
 import xqueryPlugin from "../src/main.ts";
 
-describe("if expressions", async (d) => {
-	it("formats a simple case", async () => {
-		const code = `
+const cases = [
+	{
+		name: "formats a simple case",
+		input: `
 if (1) then
   2
 else
   3
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (1) then
+  2
+else
+  3
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats a nested if case", async () => {
-		const code = `
+	{
+		name: "formats a nested if , case",
+		input: `
 if (1) then
   2
 else if (3) then
   4
 else
   5
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (1) then
+  2
+else if (3) then
+  4
+else
+  5
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats a if case with parenthess", async () => {
-		const code = `
+	{
+		name: "formats a if case , with parenthess",
+		input: `
 if (1) then (
   2
 ) else if (3) then (
@@ -45,17 +50,21 @@ if (1) then (
 ) else (
   5
 )
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (1) then (
+  2
+) else if (3) then (
+  4
+) else (
+  5
+)
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats a if case with parentheses and comments", async () => {
-		const code = `
+	{
+		name: "formats a if case , with parentheses and comments",
+		input: `
 if (1) then (
   (: a :)
   2
@@ -65,72 +74,130 @@ if (1) then (
 ) else (
   (: c :)
 )
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (1) then (
+  (: a :)
+  2
+) else if (3) then (
+  (: b :)
+  4
+) else (
+  (: c :)
+)
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats the case with empty sequences in the then", async () => {
-		const code = `
+	{
+		name: "formats the case with , empty sequences in the then",
+		input: `
 if (true()) then (
 ) else (
   "Hello World!"
 )
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (true()) then (
+) else (
+  "Hello World!"
+)
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats the case with empty sequences in the else", async () => {
-		const code = `
+	{
+		name: "formats the case with , empty sequences in the else",
+		input: `
 if (true()) then
   "Hello world!"
 else (
 )
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (true()) then
+  "Hello world!"
+else (
+)
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats the case with empty sequences in both the else as the then", async () => {
-		const code = `
+	{
+		name: "formats the case with , empty sequences in both the else as the then",
+		input: `
 if (true()) then (
 ) else (
 )
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (true()) then (
+) else (
+)
+`.trimStart(),
+	},
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
-
-	it("formats the case with empty sequences but comments in both the else as the then", async () => {
-		const code = `
+	{
+		name: "formats the case with , empty sequences but comments in both the else as the then",
+		input: `
 if (true()) then (
   (: A :)
 ) else (
   (: B :)
 )
-`.trimStart();
-		const result = await prettier.format(code, {
-			parser: "xquery",
-			plugins: [xqueryPlugin],
-		});
+`.trimStart(),
+		output: `
+if (true()) then (
+  (: A :)
+) else (
+  (: B :)
+)
+`.trimStart(),
+	},
+	{
+		name: "Should retain newlines in comments. TODO: fix indent on the comments on an else.",
+		input: `
+(: Handle A case :)
+if (A) then
+  A
 
-		assert.strictEqual(result, code, "The input was already formatted correctly");
-	});
+(: Handle B case :)
+else if (B) then
+  B
+
+(: Handle C case :)
+else if (C) then
+  C
+
+else
+  D
+`.trimStart(),
+		output: `
+(: Handle A case :)
+if (A) then
+  A
+
+  (: Handle B case :)
+else if (B) then
+  B
+
+  (: Handle C case :)
+else if (C) then
+  C
+
+else
+  D
+`.trimStart(),
+	},
+];
+
+describe("if expressions", async () => {
+	for (const test of cases) {
+		it(test.name, async () => {
+			const code = test.input;
+			const result = await prettier.format(code, {
+				parser: "xquery",
+				plugins: [xqueryPlugin],
+			});
+
+			assert.strictEqual(result, test.output);
+		});
+	}
 });


### PR DESCRIPTION
Following the empty line rationale of Prettier. Implemented for FLWOR expressions and if/then/else expressions. If they were there to begin with: keep one empty line in.

 @bwbohl, you might wanna check this out :wink: